### PR TITLE
fix(storage): migrar a STORAGES de Django 5.1 y agregar 'storages' a …

### DIFF
--- a/gimnasio/settings.py
+++ b/gimnasio/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'rest_framework_simplejwt',
     'rest_framework_simplejwt.token_blacklist',
+    'storages',
     'gimnasioApp',
 ]
 
@@ -167,12 +168,19 @@ AWS_S3_REGION_NAME = 'us-east-1'
 AWS_DEFAULT_ACL = 'public-read'
 AWS_S3_SIGNATURE_VERSION = 's3v4'
 AWS_S3_FILE_OVERWRITE = False
-DEFAULT_FILE_STORAGE = 'gimnasioApp.storage.SupabaseMediaStorage'
+# Django 5.1 unified STORAGES setting (replaces DEFAULT_FILE_STORAGE y STATICFILES_STORAGE)
+STORAGES = {
+    'default': {
+        'BACKEND': 'gimnasioApp.storage.SupabaseMediaStorage',
+    },
+}
 
 # This production code might break development mode, so we check whether we're in DEBUG mode
 if not DEBUG:   
     STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    STORAGES['staticfiles'] = {
+        'BACKEND': 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+    }
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field

--- a/gimnasioApp/storage.py
+++ b/gimnasioApp/storage.py
@@ -2,6 +2,5 @@ from storages.backends.s3boto3 import S3Boto3Storage
 
 
 class SupabaseMediaStorage(S3Boto3Storage):
-    location = 'fotos'
     file_overwrite = False
     default_acl = 'public-read'

--- a/gimnasioApp/tests.py
+++ b/gimnasioApp/tests.py
@@ -199,10 +199,10 @@ class UserViewSetCreateTest(TestCase):
 class SupabaseMediaStorageTest(TestCase):
     """Unit tests for SupabaseMediaStorage configuration."""
 
-    def test_storage_uses_correct_location(self):
-        """Storage should use 'fotos' as location (bucket subpath)."""
+    def test_storage_uses_empty_location(self):
+        """Storage should use '' as location (upload_to='fotos/' en el modelo maneja el path)."""
         storage = SupabaseMediaStorage()
-        self.assertEqual(storage.location, 'fotos')
+        self.assertEqual(storage.location, '')
 
     def test_storage_does_not_overwrite_files(self):
         """Storage should NOT overwrite existing files (file_overwrite=False)."""
@@ -215,7 +215,7 @@ class SupabaseMediaStorageTest(TestCase):
         self.assertEqual(storage.default_acl, 'public-read')
 
     @patch.dict('os.environ', {
-        'AWS_S3_ENDPOINT_URL': 'https://test-project.supabase.co/storage/v1',
+        'AWS_S3_ENDPOINT_URL': 'https://test-project.supabase.co/storage/v1/s3',
         'AWS_ACCESS_KEY_ID': 'test-key',
         'AWS_SECRET_ACCESS_KEY': 'test-secret',
         'AWS_STORAGE_BUCKET_NAME': 'test-bucket'
@@ -224,13 +224,13 @@ class SupabaseMediaStorageTest(TestCase):
         """Storage should read S3 endpoint from AWS_S3_ENDPOINT_URL env var."""
         from django.test.utils import override_settings
         with override_settings(
-            AWS_S3_ENDPOINT_URL='https://test-project.supabase.co/storage/v1',
+            AWS_S3_ENDPOINT_URL='https://test-project.supabase.co/storage/v1/s3',
             AWS_ACCESS_KEY_ID='test-key',
             AWS_SECRET_ACCESS_KEY='test-secret',
             AWS_STORAGE_BUCKET_NAME='test-bucket'
         ):
             storage = SupabaseMediaStorage()
-            self.assertEqual(storage.endpoint_url, 'https://test-project.supabase.co/storage/v1')
+            self.assertEqual(storage.endpoint_url, 'https://test-project.supabase.co/storage/v1/s3')
 
     @patch.dict('os.environ', {'AWS_STORAGE_BUCKET_NAME': 'custom-bucket'})
     def test_storage_uses_configured_bucket_name(self):


### PR DESCRIPTION
…INSTALLED_APPS

- Reemplazar DEFAULT_FILE_STORAGE (deprecado en 5.1) por STORAGES
- Agregar 'storages' a INSTALLED_APPS para inicialización correcta
- Actualizar tests para storage sin location y endpoint /storage/v1/s3
- Eliminar location duplicado en storage.py (upload_to='fotos/' en modelo)