### PR TITLE
fix(types): agregar multiplier a AsignacionTotal para resolver error …

### DIFF
--- a/gimnasioReact/src/pages/admin/asignadaMemberShips/ListAsignarMemberShips.tsx
+++ b/gimnasioReact/src/pages/admin/asignadaMemberShips/ListAsignarMemberShips.tsx
@@ -38,6 +38,7 @@ interface AsignacionTotal {
     dateFinal?:   string;
     price: number | string;
     estado_pago?: string;
+    multiplier?: never;
 }
 
 type Asignacion = AsignacionTotal | AsignarMemberShips;


### PR DESCRIPTION
…TS en union type

- AsignacionTotal ahora tiene multiplier?: never
- Esto permite acceder a row.multiplier en la union AsignacionTotal | AsignarMemberShips