### PR TITLE
fix: traducir y reubicar cards de stats, corregir retention rate

### DIFF
--- a/gimnasioApp/views.py
+++ b/gimnasioApp/views.py
@@ -244,26 +244,27 @@ class DashboardStatsView(APIView):
         else:
             prev_month_end = date(prev_year, prev_month + 1, 1) - timedelta(days=1)
         
-        # Miembros que tenían membresía activa el mes anterior
-        prev_active = MembresiaAsignada.objects.filter(
+        # Miembros únicos activos el mes anterior (distinct por miembro)
+        prev_active_ids = MembresiaAsignada.objects.filter(
             miembro__gimnasio=gimnasio,
             dateInitial__lte=prev_month_end,
             dateFinal__gte=prev_month_start
-        ).count()
+        ).values_list('miembro', flat=True).distinct()
+        prev_active_count = len(prev_active_ids)
         
-        # Miembros que estavam activos el mes anterior Y aún siguen activos
-        from django.db.models import Q
-        still_active = MembresiaAsignada.objects.filter(
-            miembro__gimnasio=gimnasio,
-            dateInitial__lte=prev_month_end,
-            dateFinal__gte=prev_month_start
-        ).filter(
-            dateFinal__gte=today
-        ).count()
+        # De esos miembros, cuántos siguen activos hoy (con cualquier membresía)
+        still_active_count = 0
+        if prev_active_count > 0:
+            still_active_count = MembresiaAsignada.objects.filter(
+                miembro__in=list(prev_active_ids),
+                miembro__gimnasio=gimnasio,
+                dateFinal__gte=today,
+                dateInitial__lte=today
+            ).values('miembro').distinct().count()
         
         # Calcular retention
-        if prev_active > 0:
-            retention = round((still_active / prev_active) * 100, 1)
+        if prev_active_count > 0:
+            retention = round((still_active_count / prev_active_count) * 100, 1)
         else:
             retention = 100.0  # Si no hay miembros anteriores, 100%
         

--- a/gimnasioReact/src/components/table/section/StatsOverviewSection.tsx
+++ b/gimnasioReact/src/components/table/section/StatsOverviewSection.tsx
@@ -41,11 +41,11 @@ const StatsOverviewSection = () => {
                     </div>
                 </article>
                 <article className="bg-surface-container-lowest border-b-2 border-primary/10 flex flex-col justify-between p-6 rounded-xl shadow-sm">
-                    <p className="font-bold text-on-surface text-xs tracking-widest uppercase">Retention Rate</p>
+                    <p className="font-bold text-on-surface text-xs tracking-widest uppercase">Tasa de Retención</p>
                     <h3 className="font-black text-3xl text-on-surface tracking-tighter">...</h3>
                 </article>
                 <article className="bg-surface-container-lowest border-b-2 border-primary/10 flex flex-col justify-between p-6 rounded-xl shadow-sm">
-                    <p className="font-bold text-on-surface text-xs tracking-widest uppercase">New Today</p>
+                    <p className="font-bold text-on-surface text-xs tracking-widest uppercase">Nuevos Hoy</p>
                     <h3 className="font-black text-3xl text-on-surface tracking-tighter">...</h3>
                 </article>
             </section>
@@ -71,7 +71,7 @@ const StatsOverviewSection = () => {
                 </div>
             </article>
             <article className="bg-surface-container-lowest border-b-2 border-primary/10 flex flex-col justify-between p-6 rounded-xl shadow-sm">
-                <p className="font-bold text-on-surface text-xs tracking-widest uppercase">Retention Rate</p>
+                <p className="font-bold text-on-surface text-xs tracking-widest uppercase">Tasa de Retención</p>
                 <h3 className="font-black text-3xl text-on-surface tracking-tighter">
                     {stats.retention_rate}%
                 </h3>
@@ -83,7 +83,7 @@ const StatsOverviewSection = () => {
                 </div>
             </article>
             <article className="bg-surface-container-lowest border-b-2 border-primary/10 flex flex-col justify-between p-6 rounded-xl shadow-sm">
-                <p className="font-bold text-on-surface text-xs tracking-widest uppercase">New Today</p>
+                <p className="font-bold text-on-surface text-xs tracking-widest uppercase">Nuevos Hoy</p>
                 <h3 className="font-black text-3xl text-on-surface tracking-tighter">
                     {stats.new_today}
                 </h3>

--- a/gimnasioReact/src/pages/admin/asignadaMemberShips/ListAsignarMemberShips.tsx
+++ b/gimnasioReact/src/pages/admin/asignadaMemberShips/ListAsignarMemberShips.tsx
@@ -11,7 +11,6 @@ import Table from '../../../components/Table';
 import ActionButtons from "../../../components/table/ActionButton";
 // components Sections
 import HeaderSection from "../../../components/table/section/HeaderSection";
-import StatsOverviewSection from "../../../components/table/section/StatsOverviewSection";
 //Mensajes
 import { toast } from 'react-hot-toast';
 // icons
@@ -249,7 +248,7 @@ const ListAsignarMemberShips = () => {
                 title="Listado de Asignación"
                 highlight="Membresías" 
             />
-            <StatsOverviewSection />            
+            
             {/* Busqueda */}
             <section className="relative w-full">
                 <span className="absolute left-3 text-lg text-nav top-1/2 -translate-y-1/2"><IoSearch /></span>

--- a/gimnasioReact/src/pages/admin/memberShips/ListMemberShips.tsx
+++ b/gimnasioReact/src/pages/admin/memberShips/ListMemberShips.tsx
@@ -9,7 +9,6 @@ import Table from '../../../components/Table';
 import ActionButtons from "../../../components/table/ActionButton";
 // components Sections
 import HeaderSection from "../../../components/table/section/HeaderSection";
-import StatsOverviewSection from "../../../components/table/section/StatsOverviewSection";
 //Mensajes
 import { toast } from 'react-hot-toast';
 //Models
@@ -156,7 +155,7 @@ const ListMemberShips = () => {
                 title="Listado de"
                 highlight="Membresías" 
             />
-            <StatsOverviewSection />           
+
             {
                 isLoading ? (
                     <div className="text-center py-4">Buscando...</div>

--- a/gimnasioReact/src/pages/admin/registroPorDia/ListMiembroDay.tsx
+++ b/gimnasioReact/src/pages/admin/registroPorDia/ListMiembroDay.tsx
@@ -177,7 +177,7 @@ const ListMiembroDay = () => {
                 title="Listado de Miembros por"
                 highlight="Día" 
             />
-            <StatsOverviewSection />            
+            <StatsOverviewSection />
             {/* Busqueda */}
             <section className="relative w-full">
                 <span className="absolute left-3 text-lg text-nav top-1/2 -translate-y-1/2"><IoSearch /></span>

--- a/gimnasioReact/src/pages/admin/usuarios/ListUser.tsx
+++ b/gimnasioReact/src/pages/admin/usuarios/ListUser.tsx
@@ -7,7 +7,6 @@ import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import Table from '../../../components/Table';
 // components Sections
 import HeaderSection from "../../../components/table/section/HeaderSection";
-import StatsOverviewSection from "../../../components/table/section/StatsOverviewSection";
 //Mensajes
 import { toast } from 'react-hot-toast';
 //Models
@@ -81,7 +80,6 @@ const ListUser = () => {
                 title="Listado de"
                 highlight="Usuarios" 
             />
-            <StatsOverviewSection />
             {
                 isLoading ? (
                     <div className="text-center py-4">Cargando...</div>


### PR DESCRIPTION
- Traduce 'Retention Rate' → 'Tasa de Retención' y 'New Today' → 'Nuevos Hoy'
- Elimina StatsOverviewSection de pantallas donde no aplica: usuarios, membresías, asignaciones
- Mantiene las cards en listado de miembros y miembros por día
- Corrige retention rate para contar miembros únicos en vez de registros de membresía (renovaciones ahora cuentan como retención)